### PR TITLE
Add basic trip viewing skeleton and dummy trips

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { LoginComponent } from './component/login/login.component';
 import { SignupComponent } from './component/signup/signup.component';
 import { LogoutComponent } from './component/logout/logout.component';
 import { HomeComponent } from './component/home/home.component';
+import { TripsComponent } from './component/trips/trips.component';
 
 const routes = [
     { path: '', component: IndexComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,9 @@ import { SignupService } from './service/signup.service';
 import { AuthenticationService } from './service/authentication.service';
 import { LogoutComponent } from './component/logout/logout.component';
 import { HomeComponent } from './component/home/home.component';
+import { TripsComponent } from './component/trips/trips.component';
+import { TripService } from './service/trip.service';
+import { HttpClientModule } from '@angular/common/http';
 
 
 @NgModule({
@@ -23,18 +26,21 @@ import { HomeComponent } from './component/home/home.component';
         IndexComponent,
         SignupComponent,
         LogoutComponent,
-        HomeComponent
+        HomeComponent,
+        TripsComponent
     ],
     imports: [
         BrowserModule,
         FormsModule,
-        AppRoutingModule
+        AppRoutingModule,
+        HttpClientModule
     ],
     providers: [
         CognitoService,
         LoginService,
         SignupService,
-        AuthenticationService
+        AuthenticationService,
+        TripService
     ],
     bootstrap: [AppComponent]
 })

--- a/src/app/component/home/home.component.html
+++ b/src/app/component/home/home.component.html
@@ -1,3 +1,6 @@
-<h1 class="display-4">Welcome</h1>
+<h1 class="display-4">Trips</h1>
 <p class="lead" *ngIf="user">Hello, {{ user.name }}</p>
-<a class="btn btn-primary btn-lg" routerLink="/logout" role="button">Log Out</a>
+<div *ngIf="user">
+    <app-trips></app-trips>
+</div>
+<a class="btn btn-primary" routerLink="/logout" role="button">Log Out</a>

--- a/src/app/component/home/home.component.spec.ts
+++ b/src/app/component/home/home.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { HomeComponent } from './home.component';
 import { AuthenticationService } from '../../service/authentication.service';
@@ -6,6 +7,8 @@ import { CognitoService } from '../../service/cognito.service';
 import { Router } from '@angular/router';
 import { RouterStub } from '../../testing/router-stubs';
 import { AuthenticationServiceStub } from '../../testing/authentication-service-stub';
+import { TripsComponent } from '../trips/trips.component';
+import { TripService } from '../../service/trip.service';
 
 
 
@@ -18,10 +21,12 @@ describe('HomeComponent', () => {
     beforeEach(async(() => {
         routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl']);
         TestBed.configureTestingModule({
-            declarations: [ HomeComponent ],
+            imports: [ HttpClientTestingModule ],
+            declarations: [ HomeComponent, TripsComponent ],
             providers: [ 
                 { provide: AuthenticationService, useClass: AuthenticationServiceStub }, 
-                { provide: Router, useValue: routerSpy }
+                { provide: Router, useValue: routerSpy },
+                TripService
             ]
         })
         .compileComponents();

--- a/src/app/component/trips/trips.component.html
+++ b/src/app/component/trips/trips.component.html
@@ -1,0 +1,20 @@
+<table class="table">
+    <thead>
+        <tr>
+            <th scope="col">Source</th>
+            <th scope="col">Destination</th>
+            <th scope="col">Driver</th>
+            <th scope="col">Seats</th>
+            <th scope="col">Smoking</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let trip of trips">
+            <td>{{ trip.source }}</td>
+            <td>{{ trip.dest }}</td>
+            <td>{{ trip.driver }}</td>
+            <td>{{ trip.seats }}</td>
+            <td>{{ trip.smoking ? 'Y' : 'N' }}</td>
+        </tr>
+    </tbody>
+</table>

--- a/src/app/component/trips/trips.component.spec.ts
+++ b/src/app/component/trips/trips.component.spec.ts
@@ -1,0 +1,29 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { TripsComponent } from './trips.component';
+import { TripService } from '../../service/trip.service';
+
+describe('TripsComponent', () => {
+    let component: TripsComponent;
+    let fixture: ComponentFixture<TripsComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [ HttpClientTestingModule ],
+            declarations: [ TripsComponent ],
+            providers: [TripService]
+        })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TripsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/app/component/trips/trips.component.ts
+++ b/src/app/component/trips/trips.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { TripService } from '../../service/trip.service';
+
+@Component({
+    selector: 'app-trips',
+    templateUrl: './trips.component.html',
+    styleUrls: ['./trips.component.css']
+})
+export class TripsComponent implements OnInit {
+    public trips = [
+        { source: 'Champaign, IL', dest: 'Chicago, IL', driver: 'Bob Smith', seats: 4, smoking: false },
+        { source: 'Indianapolis, IN', dest: 'Dayton, OH', driver: 'Brian Kurek', seats: 2, smoking: false },
+        { source: 'Orlando, FL', dest: 'Champaign, IL', driver: 'Christian Cygnus', seats: 3, smoking: false}
+    ];
+
+    constructor(private tripService: TripService) { }
+
+    ngOnInit() {
+        
+    }
+
+}

--- a/src/app/service/trip.service.spec.ts
+++ b/src/app/service/trip.service.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { TripService } from './trip.service';
+
+describe('TripService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule ],
+      providers: [TripService]
+    });
+  });
+
+  it('should be created', inject([TripService], (service: TripService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/service/trip.service.ts
+++ b/src/app/service/trip.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+
+import { environment } from '../../environments/environment';
+
+const TRIP_URL = `${environment.apiGatewayUrl}/trip`;
+
+@Injectable()
+export class TripService {
+
+    constructor(private http: HttpClient) { }
+
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,5 +7,6 @@ export const environment = {
     production: false,
     awsRegion: 'us-east-2',
     cognitoUserPoolId: 'us-east-2_OHZrHKLGQ',
-    cognitoClientId: '6v1br4a8fhl3cgmlt8fu3j6foi'
+    cognitoClientId: '6v1br4a8fhl3cgmlt8fu3j6foi',
+    apiGatewayUrl: 'https://99sepehum8.execute-api.us-east-2.amazonaws.com/prod'
 };


### PR DESCRIPTION
Initial skeleton for viewing trips. Currently only displaying dummy data because of issues connecting with the backend (CORS). Merging this branch now so we can tag what was done in Iteration 3. Much more work will be done on these features in the next iteration once we get the backend CORS issues sorted out.